### PR TITLE
Add Model Selection Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,14 @@ Before using action.similar-package-reviewer, you need to have an OpenAI API key
 
 ## Inputs
 
+## Inputs
+
 | Name               | Description                                                                                                                                                               | Default                       | Required |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | -------- |
 | `openai_key`       | openai api key                                                                                                                                                            |                               | Yes      |
 | `origin_branch`    | The branch to be used as the base for comparison, typically the main branch of the project. Can be customized if needed.                                                  | origin/${{ github.base_ref }} | No       |
 | `target_branch`    | The branch associated with the pull request, which contains the changes to be compared against the origin branch. Can be customized if needed.                            | origin/${{ github.head_ref }} | No       |
+| `model`            | Specifies the ChatGPT model to be used for analyzing pull requests. Different models may provide varying levels of analysis accuracy and performance.                     | gpt-3.5-turbo                 | No       |
 | `use_functioncall` | Indicates whether to use the functioncall feature of ChatGPT. Using functioncall can provide more stable execution but may produce slightly different comparison results. | false                         | No       |
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   use_functioncall:
     description: 'Indicates whether to use the functioncall feature of ChatGPT. Using functioncall can provide more stable execution but may produce slightly different comparison results.'
     default: false
+  model:
+    description: 'Specifies the ChatGPT model to be used for analyzing pull requests. Different models may provide varying levels of analysis accuracy and performance. Default is gpt-3.5-turbo.'
+    default: gpt-3.5-turbo
 
 outputs:
   results:

--- a/src/inputHelper.ts
+++ b/src/inputHelper.ts
@@ -11,6 +11,7 @@ export function getInputs() {
     originBranch: core.getInput('origin_branch', { required: true }),
     targetBranch: core.getInput('target_branch', { required: true }),
     useFunctionCall: core.getInput('use_functioncall') === 'true',
+    model: core.getInput('model'),
   };
   return inputs;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import * as textFormatHelper from './textFormatHelper';
 import * as summaryHelper from './summaryHelper';
 
 async function run(): Promise<void> {
-  const { openaiKey, originBranch, targetBranch, useFunctionCall } =
+  const { openaiKey, originBranch, targetBranch, useFunctionCall, model } =
     inputHelper.getInputs();
 
   core.startGroup('Get Package List');
@@ -33,6 +33,7 @@ async function run(): Promise<void> {
     openaiKey,
     originPackages,
     addedPackages,
+    model,
   );
   core.endGroup();
 

--- a/src/openaiHelper.ts
+++ b/src/openaiHelper.ts
@@ -60,6 +60,7 @@ export async function comparePackagesUsingMessage(
   openaiKey: string,
   originPackages: string[],
   addedPackages: string[],
+  model: string,
 ): Promise<PackageSimilarityResult[]> {
   const configuration = new Configuration({
     apiKey: openaiKey,
@@ -70,7 +71,7 @@ export async function comparePackagesUsingMessage(
   core.debug(`prompt: ${content}`);
 
   const completion = await openai.createChatCompletion({
-    model: 'gpt-3.5-turbo-0613',
+    model,
     messages: [
       { role: 'system', content: SYSTEM_PROMPT },
       { role: 'user', content },
@@ -98,6 +99,7 @@ export async function comparePackagesUsingFunctionCall(
   openaiKey: string,
   originPackages: string[],
   addedPackages: string[],
+  model: string,
 ): Promise<PackageSimilarityResult[]> {
   const configuration = new Configuration({
     apiKey: openaiKey,
@@ -108,7 +110,7 @@ export async function comparePackagesUsingFunctionCall(
   core.debug(`prompt: ${content}`);
 
   const completion = await openai.createChatCompletion({
-    model: 'gpt-3.5-turbo-0613',
+    model,
     messages: [
       { role: 'system', content: SYSTEM_PROMPT },
       { role: 'user', content },

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -15,4 +15,5 @@ type Inputs = {
   originBranch: string;
   targetBranch: string;
   useFunctionCall: boolean;
+  model: string;
 };


### PR DESCRIPTION
### Description:
This PR introduces a new input option for specifying the ChatGPT model to be used when analyzing pull requests for similar package dependencies. By providing a model selection option, users can now choose different versions of ChatGPT models based on their needs and preferences.

- Added a new `model` input in the action.yml file with a default value of `gpt-3.5-turbo`.
- Updated README to include information about the new `model` input option.
- Resolves [Issue #4](https://github.com/hmu332233/action.similar-package-reviewer/issues/4).
